### PR TITLE
Add support for nested metadata files

### DIFF
--- a/pkg/metadata/file.go
+++ b/pkg/metadata/file.go
@@ -13,7 +13,9 @@ type Metamap map[string]interface{}
 
 func Parse() (Metamap, error) {
 	metapath := core.Get("core.path.metadata")
-	metafiles, err := util.ReadGlob(metapath + "/*.y*ml")
+	metafilesRoot, err := util.ReadGlob(metapath + "/*.y*ml")
+	metafilesNested, err := util.ReadGlob(metapath + "/*/*.y*ml")
+	metafiles := append(metafilesRoot, metafilesNested...)
 	metadata := Metamap{}
 
 	if err != nil {

--- a/pkg/metadata/file_test.go
+++ b/pkg/metadata/file_test.go
@@ -41,6 +41,23 @@ func TestParseWithMerge(t *testing.T) {
 	os.RemoveAll(tmpdir)
 }
 
+func TestParseWithMergeNested(t *testing.T) {
+	tmpdir := test.MkTempDir(t)
+	os.Mkdir(tmpdir + "/nested/", 0750)
+	test.DumpFile(t, fmt.Sprintf("%s/defaults.yml", tmpdir), "test: data")
+	test.DumpFile(t, fmt.Sprintf("%s/nested/additionals.yaml", tmpdir), "info: data")
+
+	core.Init()
+	core.Set("core.path.metadata", tmpdir)
+
+	expected := Metamap{"test": "data", "info": "data"}
+	actual, err := Parse()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+
+	os.RemoveAll(tmpdir)
+}
+
 func TestParseWithGarbage(t *testing.T) {
 	tmpdir := test.MkTempDir(t)
 	test.DumpFile(t, fmt.Sprintf("%s/defaults.yml", tmpdir), "test: data")


### PR DESCRIPTION
## What?

This PR allows kaigara to load nested metadata files.

## Why?

Because when mounting Secret/ConfigMap objects from k8s to `/etc/kaigara/metadata` it will hide all files provided by the container. So if the container ships with a reasonable `/etc/kaigara/metadata/00-default.yaml` and we want to overwrite only a limited set of configuration attributes from k8s with a file like `/etc/kaigara/metadata/99-k8s.yaml` we're out of luck. 

But with the PR we can mount the k8s file to `/etc/kaigara/metadata/k8s/additions.yaml` and continue with our life :-)

## `/*.y*ml` **and** `/*/*.y*ml`? Srsly?

I'm a total go newbie, this seems to work and, as far as google told me, go does not support `**`-globs. Feel free to change! :-D